### PR TITLE
Incremental update to torrent state + remove extraneous metrics.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dashboards/jsonnetfile.lock.json
 /dashboards/vendor/
 /transmission-exporter
+/cmd/transmission-exporter/transmission-exporter
 
 *.o
 *.a

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ I made these changes because the latency of fetching metrics was too slow. My ch
 Summary of changes made in this fork:
 
 * Instead of grabbing every torrent, it uses the RPC query `"ids": "recently-active"` to only grab recently active torrents. It still grabs every torrent on the first run, then does recently active only from then on. A map is used to maintain torrents current status, the key is the torrent hash. This way the metrics stay available, they just don't change while the torrent is dormant. This is faster since Transmission doesn't serialize and send unchanged information.
-* Fields for files, peers, and trackes are all removed. **These metrics are no longer exported,** and they are no longer requested as fields in RPC calls. So, **this fork has less functionality**, but it's faster. Those metrics aren't interesting anyway. :)
+* Fields for files, peers, and trackers are all removed. **These metrics are no longer exported,** and they are no longer requested as fields in RPC calls. So, **this fork has less functionality**, but it's faster. Those metrics aren't interesting anyway. :)
 * New exported metric `uploaded_ever_bytes`. Technically you could compute this by multiplying the ratio by the size, but I would rather just export the actual integer. Transmission will tell you this if you ask, so `uploadedEver` was added to the list of fields requested from its RPC.
 * `lastScrapeTimedOut` issue fixed by simply changing datatype in JSON struct from bool to int

--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Summary of changes made in this fork:
 * Fields for files, peers, and trackers are all removed. **These metrics are no longer exported,** and they are no longer requested as fields in RPC calls. So, **this fork has less functionality**, but it's faster. Those metrics aren't interesting anyway. :)
 * New exported metric `uploaded_ever_bytes`. Technically you could compute this by multiplying the ratio by the size, but I would rather just export the actual integer. Transmission will tell you this if you ask, so `uploadedEver` was added to the list of fields requested from its RPC.
 * `lastScrapeTimedOut` issue fixed by simply changing datatype in JSON struct from bool to int
+* Also added a bunch more exported metrics: `downloaded_ever_bytes`, `peers_connected`, `peers_getting_from_us`, `peers_sending_to_us`
+
+
+TODO (not implemented yet)
+* As per https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md, when using this `recently-active` thing, there is an additional reply called `removed` which is a list of torrents that were removed. I currently ignore this, because I virtually never remove torrents. But just saying, this exporter will not remove torrents, because it doesn't parse this reply. I guess you could restart the exporter after removing torrents?

--- a/cmd/transmission-exporter/main.go
+++ b/cmd/transmission-exporter/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
-			<head><title>Node Exporter</title></head>
+			<head><title>Transmission Exporter</title></head>
 			<body>
 			<h1>Transmission Exporter</h1>
 			<p><a href="` + c.WebPath + `">Metrics</a></p>

--- a/cmd/transmission-exporter/torrent_collector.go
+++ b/cmd/transmission-exporter/torrent_collector.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"strconv"
+	"sync"
 
 	transmission "github.com/metalmatze/transmission-exporter"
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,19 +17,19 @@ const (
 type TorrentCollector struct {
 	client *transmission.Client
 
-	Status   *prometheus.Desc
-	Added    *prometheus.Desc
-	Files    *prometheus.Desc
-	Finished *prometheus.Desc
-	Done     *prometheus.Desc
-	Ratio    *prometheus.Desc
-	Download *prometheus.Desc
-	Upload   *prometheus.Desc
+	Status       *prometheus.Desc
+	Added        *prometheus.Desc
+	Finished     *prometheus.Desc
+	Done         *prometheus.Desc
+	Ratio        *prometheus.Desc
+	Download     *prometheus.Desc
+	Upload       *prometheus.Desc
+	UploadedEver *prometheus.Desc
 
-	// TrackerStats
-	Downloads *prometheus.Desc
-	Leechers  *prometheus.Desc
-	Seeders   *prometheus.Desc
+	recentlyActiveOnly bool
+
+	cachedTorrents     map[string]transmission.Torrent
+	cachedTorrentsLock sync.Mutex
 }
 
 // NewTorrentCollector creates a new torrent collector with the transmission.Client
@@ -36,7 +37,8 @@ func NewTorrentCollector(client *transmission.Client) *TorrentCollector {
 	const collectorNamespace = "torrent_"
 
 	return &TorrentCollector{
-		client: client,
+		cachedTorrents: make(map[string]transmission.Torrent),
+		client:         client,
 
 		Status: prometheus.NewDesc(
 			namespace+collectorNamespace+"status",
@@ -46,12 +48,6 @@ func NewTorrentCollector(client *transmission.Client) *TorrentCollector {
 		),
 		Added: prometheus.NewDesc(
 			namespace+collectorNamespace+"added",
-			"The unixtime time a torrent was added",
-			[]string{"id", "name"},
-			nil,
-		),
-		Files: prometheus.NewDesc(
-			namespace+collectorNamespace+"files_total",
 			"The unixtime time a torrent was added",
 			[]string{"id", "name"},
 			nil,
@@ -87,23 +83,10 @@ func NewTorrentCollector(client *transmission.Client) *TorrentCollector {
 			nil,
 		),
 
-		// TrackerStats
-		Downloads: prometheus.NewDesc(
-			namespace+collectorNamespace+"downloads_total",
-			"How often this torrent was downloaded",
-			[]string{"id", "name", "tracker"},
-			nil,
-		),
-		Leechers: prometheus.NewDesc(
-			namespace+collectorNamespace+"leechers",
-			"The number of peers downloading this torrent",
-			[]string{"id", "name", "tracker"},
-			nil,
-		),
-		Seeders: prometheus.NewDesc(
-			namespace+collectorNamespace+"seeders",
-			"The number of peers uploading this torrent",
-			[]string{"id", "name", "tracker"},
+		UploadedEver: prometheus.NewDesc(
+			namespace+collectorNamespace+"uploaded_ever_bytes",
+			"The amount of bytes that have been uploaded from this torrent ever",
+			[]string{"id", "name"},
 			nil,
 		),
 	}
@@ -113,26 +96,36 @@ func NewTorrentCollector(client *transmission.Client) *TorrentCollector {
 func (tc *TorrentCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- tc.Status
 	ch <- tc.Added
-	ch <- tc.Files
 	ch <- tc.Finished
 	ch <- tc.Done
 	ch <- tc.Ratio
 	ch <- tc.Download
 	ch <- tc.Upload
-	ch <- tc.Downloads
-	ch <- tc.Leechers
-	ch <- tc.Seeders
+	ch <- tc.UploadedEver
 }
 
 // Collect implements the prometheus.Collector interface
 func (tc *TorrentCollector) Collect(ch chan<- prometheus.Metric) {
-	torrents, err := tc.client.GetTorrents()
+	torrents, err := tc.client.GetTorrents(tc.recentlyActiveOnly)
 	if err != nil {
 		log.Printf("failed to get torrents: %v", err)
 		return
 	}
-
+	tc.cachedTorrentsLock.Lock()
+	var realTorrentsList []transmission.Torrent
 	for _, t := range torrents {
+		tc.cachedTorrents[t.HashString] = t
+	}
+	for _, t := range tc.cachedTorrents {
+		realTorrentsList = append(realTorrentsList, t)
+	}
+	tc.cachedTorrentsLock.Unlock()
+
+	if len(realTorrentsList) > 0 {
+		tc.recentlyActiveOnly = true // only do this if successful
+	}
+
+	for _, t := range realTorrentsList {
 		var finished float64
 
 		id := strconv.Itoa(t.ID)
@@ -151,12 +144,6 @@ func (tc *TorrentCollector) Collect(ch chan<- prometheus.Metric) {
 			tc.Added,
 			prometheus.GaugeValue,
 			float64(t.Added),
-			id, t.Name,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			tc.Files,
-			prometheus.GaugeValue,
-			float64(len(t.Files)),
 			id, t.Name,
 		)
 		ch <- prometheus.MustNewConstMetric(
@@ -190,37 +177,11 @@ func (tc *TorrentCollector) Collect(ch chan<- prometheus.Metric) {
 			id, t.Name,
 		)
 
-		tstats := make(map[string]transmission.TrackerStat)
-
-		for _, tracker := range t.TrackerStats {
-			if tr, exists := tstats[tracker.Host]; exists {
-				tr.DownloadCount += tracker.DownloadCount
-			} else {
-				tstats[tracker.Host] = tracker
-			}
-		}
-
-		for _, tracker := range tstats {
-			ch <- prometheus.MustNewConstMetric(
-				tc.Downloads,
-				prometheus.GaugeValue,
-				float64(tracker.DownloadCount),
-				id, t.Name, tracker.Host,
-			)
-
-			ch <- prometheus.MustNewConstMetric(
-				tc.Leechers,
-				prometheus.GaugeValue,
-				float64(tracker.LeecherCount),
-				id, t.Name, tracker.Host,
-			)
-
-			ch <- prometheus.MustNewConstMetric(
-				tc.Seeders,
-				prometheus.GaugeValue,
-				float64(tracker.SeederCount),
-				id, t.Name, tracker.Host,
-			)
-		}
+		ch <- prometheus.MustNewConstMetric(
+			tc.UploadedEver,
+			prometheus.GaugeValue,
+			float64(t.UploadedEver),
+			id, t.Name,
+		)
 	}
 }

--- a/cmd/transmission-exporter/torrent_collector.go
+++ b/cmd/transmission-exporter/torrent_collector.go
@@ -17,14 +17,18 @@ const (
 type TorrentCollector struct {
 	client *transmission.Client
 
-	Status       *prometheus.Desc
-	Added        *prometheus.Desc
-	Finished     *prometheus.Desc
-	Done         *prometheus.Desc
-	Ratio        *prometheus.Desc
-	Download     *prometheus.Desc
-	Upload       *prometheus.Desc
-	UploadedEver *prometheus.Desc
+	Status             *prometheus.Desc
+	Added              *prometheus.Desc
+	Finished           *prometheus.Desc
+	Done               *prometheus.Desc
+	Ratio              *prometheus.Desc
+	Download           *prometheus.Desc
+	Upload             *prometheus.Desc
+	UploadedEver       *prometheus.Desc
+	DownloadedEver     *prometheus.Desc
+	PeersConnected     *prometheus.Desc
+	PeersGettingFromUs *prometheus.Desc
+	PeersSendingToUs   *prometheus.Desc
 
 	recentlyActiveOnly bool
 
@@ -82,10 +86,33 @@ func NewTorrentCollector(client *transmission.Client) *TorrentCollector {
 			[]string{"id", "name"},
 			nil,
 		),
-
 		UploadedEver: prometheus.NewDesc(
 			namespace+collectorNamespace+"uploaded_ever_bytes",
-			"The amount of bytes that have been uploaded from this torrent ever",
+			"The amount of bytes that have been uploaded from a torrent ever",
+			[]string{"id", "name"},
+			nil,
+		),
+		DownloadedEver: prometheus.NewDesc(
+			namespace+collectorNamespace+"downloaded_ever_bytes",
+			"The amount of bytes that have been downloaded from a torrent ever",
+			[]string{"id", "name"},
+			nil,
+		),
+		PeersConnected: prometheus.NewDesc(
+			namespace+collectorNamespace+"peers_connected",
+			"The quantity of peers connected on a torrent",
+			[]string{"id", "name"},
+			nil,
+		),
+		PeersGettingFromUs: prometheus.NewDesc(
+			namespace+collectorNamespace+"peers_getting_from_us",
+			"The quantity of peers getting pieces of a torrent from us",
+			[]string{"id", "name"},
+			nil,
+		),
+		PeersSendingToUs: prometheus.NewDesc(
+			namespace+collectorNamespace+"peers_sending_to_us",
+			"The quantity of peers sending pieces of a torrent to us",
 			[]string{"id", "name"},
 			nil,
 		),
@@ -102,6 +129,10 @@ func (tc *TorrentCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- tc.Download
 	ch <- tc.Upload
 	ch <- tc.UploadedEver
+	ch <- tc.DownloadedEver
+	ch <- tc.PeersConnected
+	ch <- tc.PeersGettingFromUs
+	ch <- tc.PeersSendingToUs
 }
 
 // Collect implements the prometheus.Collector interface
@@ -176,11 +207,34 @@ func (tc *TorrentCollector) Collect(ch chan<- prometheus.Metric) {
 			float64(t.RateUpload),
 			id, t.Name,
 		)
-
 		ch <- prometheus.MustNewConstMetric(
 			tc.UploadedEver,
 			prometheus.GaugeValue,
 			float64(t.UploadedEver),
+			id, t.Name,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			tc.DownloadedEver,
+			prometheus.GaugeValue,
+			float64(t.DownloadedEver),
+			id, t.Name,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			tc.PeersConnected,
+			prometheus.GaugeValue,
+			float64(t.PeersConnected),
+			id, t.Name,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			tc.PeersGettingFromUs,
+			prometheus.GaugeValue,
+			float64(t.PeersGettingFromUs),
+			id, t.Name,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			tc.PeersSendingToUs,
+			prometheus.GaugeValue,
+			float64(t.PeersSendingToUs),
 			id, t.Name,
 		)
 	}

--- a/torrent.go
+++ b/torrent.go
@@ -11,7 +11,7 @@ type (
 	TorrentArguments struct {
 		Fields       []string              `json:"fields,omitempty"`
 		Torrents     []Torrent             `json:"torrents,omitempty"`
-		Ids          []int                 `json:"ids,omitempty"`
+		Ids          string                `json:"ids,omitempty"`
 		DeleteData   bool                  `json:"delete-local-data,omitempty"`
 		DownloadDir  string                `json:"download-dir,omitempty"`
 		MetaInfo     string                `json:"metainfo,omitempty"`
@@ -27,26 +27,24 @@ type (
 
 	// Torrent represents a transmission torrent
 	Torrent struct {
-		ID            int           `json:"id"`
-		Name          string        `json:"name"`
-		Status        int           `json:"status"`
-		Added         int           `json:"addedDate"`
-		LeftUntilDone int64         `json:"leftUntilDone"`
-		Eta           int           `json:"eta"`
-		UploadRatio   float64       `json:"uploadRatio"`
-		RateDownload  int           `json:"rateDownload"`
-		RateUpload    int           `json:"rateUpload"`
-		DownloadDir   string        `json:"downloadDir"`
-		IsFinished    bool          `json:"isFinished"`
-		PercentDone   float64       `json:"percentDone"`
-		SeedRatioMode int           `json:"seedRatioMode"`
-		HashString    string        `json:"hashString"`
-		Error         int           `json:"error"`
-		ErrorString   string        `json:"errorString"`
-		Files         []File        `json:"files"`
-		FilesStats    []FileStat    `json:"fileStats"`
-		TrackerStats  []TrackerStat `json:"trackerStats"`
-		Peers         []Peer        `json:"peers"`
+		ID            int     `json:"id"`
+		Name          string  `json:"name"`
+		Status        int     `json:"status"`
+		Added         int     `json:"addedDate"`
+		LeftUntilDone int64   `json:"leftUntilDone"`
+		Eta           int     `json:"eta"`
+		UploadRatio   float64 `json:"uploadRatio"`
+		RateDownload  int     `json:"rateDownload"`
+		RateUpload    int     `json:"rateUpload"`
+		DownloadDir   string  `json:"downloadDir"`
+		IsFinished    bool    `json:"isFinished"`
+		PercentDone   float64 `json:"percentDone"`
+		SeedRatioMode int     `json:"seedRatioMode"`
+		HashString    string  `json:"hashString"`
+		Error         int     `json:"error"`
+		ErrorString   string  `json:"errorString"`
+
+		UploadedEver int `json:"uploadedEver"`
 	}
 
 	// ByID implements the sort Interface to sort by ID
@@ -92,7 +90,7 @@ type (
 		LastScrapeStartTime   int    `json:"lastScrapeStartTime"`
 		LastScrapeSucceeded   bool   `json:"lastScrapeSucceeded"`
 		LastScrapeTime        int    `json:"lastScrapeTime"`
-		LastScrapeTimedOut    bool   `json:"lastScrapeTimedOut"`
+		LastScrapeTimedOut    int    `json:"lastScrapeTimedOut"`
 		LeecherCount          int    `json:"leecherCount"`
 		NextAnnounceTime      int    `json:"nextAnnounceTime"`
 		NextScrapeTime        int    `json:"nextScrapeTime"`

--- a/torrent.go
+++ b/torrent.go
@@ -27,24 +27,26 @@ type (
 
 	// Torrent represents a transmission torrent
 	Torrent struct {
-		ID            int     `json:"id"`
-		Name          string  `json:"name"`
-		Status        int     `json:"status"`
-		Added         int     `json:"addedDate"`
-		LeftUntilDone int64   `json:"leftUntilDone"`
-		Eta           int     `json:"eta"`
-		UploadRatio   float64 `json:"uploadRatio"`
-		RateDownload  int     `json:"rateDownload"`
-		RateUpload    int     `json:"rateUpload"`
-		DownloadDir   string  `json:"downloadDir"`
-		IsFinished    bool    `json:"isFinished"`
-		PercentDone   float64 `json:"percentDone"`
-		SeedRatioMode int     `json:"seedRatioMode"`
-		HashString    string  `json:"hashString"`
-		Error         int     `json:"error"`
-		ErrorString   string  `json:"errorString"`
-
-		UploadedEver int `json:"uploadedEver"`
+		ID                 int     `json:"id"`
+		Name               string  `json:"name"`
+		Status             int     `json:"status"`
+		Added              int64   `json:"addedDate"`
+		LeftUntilDone      int64   `json:"leftUntilDone"`
+		Eta                int     `json:"eta"`
+		UploadRatio        float64 `json:"uploadRatio"`
+		RateDownload       int     `json:"rateDownload"`
+		RateUpload         int     `json:"rateUpload"`
+		DownloadDir        string  `json:"downloadDir"`
+		IsFinished         bool    `json:"isFinished"`
+		PercentDone        float64 `json:"percentDone"`
+		HashString         string  `json:"hashString"`
+		Error              int     `json:"error"`
+		ErrorString        string  `json:"errorString"`
+		UploadedEver       int64   `json:"uploadedEver"`
+		DownloadedEver     int64   `json:"downloadedEver"`
+		PeersConnected     int     `json:"peersConnected"`
+		PeersGettingFromUs int     `json:"peersGettingFromUs"`
+		PeersSendingToUs   int     `json:"peersSendingToUs"`
 	}
 
 	// ByID implements the sort Interface to sort by ID

--- a/transmission.go
+++ b/transmission.go
@@ -128,11 +128,13 @@ func (c *Client) GetTorrents(recentlyActiveOnly bool) ([]Torrent, error) {
 				"downloadDir",
 				"isFinished",
 				"percentDone",
-				"seedRatioMode",
 				"error",
 				"errorString",
-
 				"uploadedEver",
+				"downloadedEver",
+				"peersConnected",
+				"peersGettingFromUs",
+				"peersSendingToUs",
 			},
 		},
 	}

--- a/transmission.go
+++ b/transmission.go
@@ -110,7 +110,7 @@ func (c *Client) authRequest(method string, body []byte) (*http.Request, error) 
 }
 
 // GetTorrents get a list of torrents
-func (c *Client) GetTorrents() ([]Torrent, error) {
+func (c *Client) GetTorrents(recentlyActiveOnly bool) ([]Torrent, error) {
 	cmd := TorrentCommand{
 		Method: "torrent-get",
 		Arguments: TorrentArguments{
@@ -131,13 +131,14 @@ func (c *Client) GetTorrents() ([]Torrent, error) {
 				"seedRatioMode",
 				"error",
 				"errorString",
-				"files",
-				"fileStats",
-				"peers",
-				"trackers",
-				"trackerStats",
+
+				"uploadedEver",
 			},
 		},
+	}
+
+	if recentlyActiveOnly {
+		cmd.Arguments.Ids = "recently-active"
 	}
 
 	req, err := json.Marshal(&cmd)


### PR DESCRIPTION
Pulls in change from the fork by @leijurv that:
- improve the performance of fetching metrics by doing a full initial pull and then incremental "recently active" fetches to only get the statistics of recently-updated torrents
- fixes the `lastScrapeTimedOut` issue https://github.com/metalmatze/transmission-exporter/issues/26
- removes a few extraneous metrics (see the notes in README in this PR specifically for more detail)